### PR TITLE
ci: window 和 linux 的 core 二进制文件增加 upx 压缩步骤

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -299,6 +299,12 @@ jobs:
           CUR_TIME: ${{ steps.currentTime.outputs.time }}
         working-directory: ./sealdice-core
         run: go build -o "output/$BINARY_NAME" -trimpath -ldflags "-s -w -X sealdice-core/dice.VERSION=$CUR_TIME($PROJECT_VERSION_S)" .
+      - name: Run UPX
+        uses: crazy-max/ghaction-upx@v3
+        with:
+          version: latest
+          files: ./sealdice-core/output/${{ env.BINARY_NAME }}
+          args: -9 -fq
       - name: Upload Core
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
压缩后体积降低至原来的 30%