### PR TITLE
tools: add a more powerful bump script

### DIFF
--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+LOCAL_BUILD_REPO='/home/ubuntu/project/sealdice-extra/build'
+SEALDICE_REMOTE_NAME='origin'
+
+set -ex
+
+PWD_NOW=$(pwd)
+cd "$LOCAL_BUILD_REPO"
+
+git fetch --all --prune
+
+git checkout dev
+git reset "$SEALDICE_REMOTE_NAME/dev" --hard
+./update-submodules.sh || true
+
+# git checkout next
+# git reset origin/next --hard
+# ./update-submodules.sh || true
+
+cd "${PWD_NOW}"
+unset PWD_NOW
+
+set +x
+
+repo='sealdice/sealdice-build'
+sleep 10s
+
+runID=$(gh -R "$repo" run list -w 'Auto Build' -b 'dev' \
+  -s 'in_progress' -L 1 --json databaseId -q '.[0].databaseId')
+
+if [[ -z $runID ]]; then
+  echo "No build in progress"
+else
+  gh -R sealdice/sealdice-build run watch "$runID"
+fi
+
+unset runID
+unset repo


### PR DESCRIPTION
功能是：

切换到本地仓库（此脚本可以从任意 PWD 调用）
拉取远程最新分支
升级 submodule
推送
恢复原来目录
调用 gh CLI 等待构建完成
