### PR TITLE
imp: 将 `update-submodules.sh` 中升级子仓库的方式换为 reset

### DIFF
--- a/update-submodules.sh
+++ b/update-submodules.sh
@@ -2,6 +2,6 @@
 git pull
 git submodule init
 git submodule update
-git submodule foreach git pull origin master
+git submodule foreach 'git fetch origin --prune && git reset --hard origin/master'
 git commit -am "chore: bump submodules"
 git push


### PR DESCRIPTION
这可以避免由于意外编辑或 force push 带来的分支不一致问题。

由于不熟悉 cmd，没有编辑 `update-submodule.cmd`