### PR TITLE
ci: 优化 dev 构建 Docker 镜像 tag 格式

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -863,7 +863,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/sealdice
           tags: |
             type=edge
-            type=sha,event=branch
+            type=raw,value={{date 'YYYYMMDD' tz='Asia/Shanghai'}}-{{sha}},event=branch
             type=ref,event=tag
       - name: Docker Build
         uses: docker/build-push-action@v3
@@ -928,7 +928,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/sealdice-full
           tags: |
             type=edge
-            type=sha,event=branch
+            type=raw,value={{date 'YYYYMMDD' tz='Asia/Shanghai'}}-{{sha}},event=branch
             type=ref,event=tag
       - name: Docker Build
         uses: docker/build-push-action@v3


### PR DESCRIPTION
## 概要

将 dev 构建时 Docker 镜像的 tag 从 `sha-xxxxxxx` 格式改为 `YYYYMMDD-<sha>` 格式（如 `20260222-abc1234`），包含日期信息，更易于辨识构建时间。

涉及 `sealdice` 和 `sealdice-full` 两个镜像。

## 改动

- `docker/metadata-action` 的 tag 规则从 `type=sha,event=branch` 改为 `type=raw,value={{date 'YYYYMMDD' tz='Asia/Shanghai'}}-{{sha}},event=branch`
- 仅影响 dev 分支 push 触发的构建，不影响 tag 事件

🤖 Generated with [Claude Code](https://claude.com/claude-code)