### PR TITLE
ci: release 构建时添加 Docker 镜像构建

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -822,12 +822,124 @@ jobs:
           files: |
             ./dist/sealdice*
 
+  docker-push:
+    name: Docker Push
+    runs-on: ubuntu-latest
+    needs:
+      - pc-pack
+      - commit-num-check
+    env:
+      PROJECT_VERSION: ${{needs.commit-num-check.outputs.PROJECT_VERSION}}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Get Amd64 Files
+        uses: actions/download-artifact@v4
+        with:
+          name: sealdice_${{ env.PROJECT_VERSION }}_linux_amd64
+          path: ./amd64/
+      - name: Get Arm64 Files
+        uses: actions/download-artifact@v4
+        with:
+          name: sealdice_${{ env.PROJECT_VERSION }}_linux_arm64
+          path: ./arm64/
+
+      - name: Chmod
+        run:
+          chmod +x ./amd64/sealdice-core && chmod +x ./arm64/sealdice-core
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/sealdice
+          tags: |
+            type=raw,value=v${{ env.PROJECT_VERSION }}
+            type=raw,value=latest
+      - name: Docker Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./scripts/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            AUTHOR=${{ github.repository_owner }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  docker-push-full:
+    name: Docker Push (Full with Lagrange)
+    runs-on: ubuntu-latest
+    needs:
+      - pc-pack
+      - commit-num-check
+    env:
+      PROJECT_VERSION: ${{needs.commit-num-check.outputs.PROJECT_VERSION}}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Get Amd64 Files
+        uses: actions/download-artifact@v4
+        with:
+          name: sealdice_${{ env.PROJECT_VERSION }}_linux_amd64
+          path: ./amd64/
+      - name: Get Arm64 Files
+        uses: actions/download-artifact@v4
+        with:
+          name: sealdice_${{ env.PROJECT_VERSION }}_linux_arm64
+          path: ./arm64/
+
+      - name: Chmod
+        run:
+          chmod +x ./amd64/sealdice-core && chmod +x ./arm64/sealdice-core
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/sealdice-full
+          tags: |
+            type=raw,value=v${{ env.PROJECT_VERSION }}
+            type=raw,value=latest
+      - name: Docker Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./scripts/Dockerfile.full
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            AUTHOR=${{ github.repository_owner }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   clear-temp-artifact:
     name: Clear Temp Artifacts
     if: always()
     runs-on: ubuntu-latest
     needs:
       - prerelease
+      - docker-push
+      - docker-push-full
     steps:
       - uses: geekyeggo/delete-artifact@v4
         with:

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:3.19.1
+
+# 指定默认时区
+RUN apk add --no-cache tzdata
+ENV TZ Asia/Shanghai
+
+
+# 固定安装目录，为避免破坏兼容性，继承旧版使用 /
+ENV SEAL_HOME=
+
+# 移入对应文件
+VOLUME ["/backups", "/data"]
+ARG TARGETARCH
+COPY ./${TARGETARCH}/data ${SEAL_HOME}/buildin-data
+COPY --chmod=0755 ./${TARGETARCH}/sealdice-core  ${SEAL_HOME}/sealdice-core
+
+RUN echo "#!/bin/sh" > ${SEAL_HOME}/entrypoint.sh
+RUN echo "mkdir -p ./data/" >> ${SEAL_HOME}/entrypoint.sh
+RUN echo "cp -r /buildin-data/* ./data/" >> ${SEAL_HOME}/entrypoint.sh
+RUN echo "/sealdice-core --container-mode" >> ${SEAL_HOME}/entrypoint.sh
+RUN chmod +x ${SEAL_HOME}/entrypoint.sh
+
+# 启动
+EXPOSE 3211
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/scripts/Dockerfile.full
+++ b/scripts/Dockerfile.full
@@ -1,0 +1,33 @@
+FROM debian:12-slim
+
+# 安装所需软件包
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        tzdata \
+        libicu72 \
+        libstdc++6 \
+    && ln -fs /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+    && dpkg-reconfigure -f noninteractive tzdata \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# 环境变量也写上，双保险
+ENV TZ=Asia/Shanghai
+
+# 移入对应文件（固定安装目录 /app，与默认镜像有区别）
+VOLUME ["/app/backups", "/app/data"]
+ARG TARGETARCH
+COPY ./${TARGETARCH}/data /app/buildin-data
+COPY --chmod=0755 ./${TARGETARCH}/sealdice-core /app/sealdice-core
+COPY ./${TARGETARCH}/lagrange /app/lagrange
+
+RUN echo '#!/bin/sh' > /app/entrypoint.sh && \
+    echo 'mkdir -p ./data/' >> /app/entrypoint.sh && \
+    echo 'rm -f ./lagrange && ln -s /app/lagrange/ ./lagrange' >> /app/entrypoint.sh && \
+    echo 'cp -r /app/buildin-data/* ./data/' >> /app/entrypoint.sh && \
+    echo 'exec /app/sealdice-core' >> /app/entrypoint.sh && \
+    chmod +x /app/entrypoint.sh
+
+# 启动
+EXPOSE 3211
+ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
## 概要

为 release 构建流程添加 Docker 镜像构建支持。release 触发时会同时构建并推送 sealdice 和 sealdice-full 两个 Docker 镜像，tag 与 release 版本号一致（如 v1.5.1），同时打 latest 标签。

## 改动

### Commit 1: 添加 Dockerfiles
从 dev 分支复制 scripts/Dockerfile（Alpine 精简版）和 scripts/Dockerfile.full（Debian + Lagrange 完整版）到 master。

### Commit 2: release-build.yml 添加 Docker jobs
- 新增 docker-push job：构建 ghcr.io/sealdice/sealdice 镜像
- 新增 docker-push-full job：构建 ghcr.io/sealdice/sealdice-full 镜像
- clear-temp-artifact 增加对 Docker jobs 的依赖，确保清理前 Docker 构建已完成